### PR TITLE
Fix duplicate registration response

### DIFF
--- a/project-root/backend/src/main/java/com/readrecords/backend/service/RegisterBookRecordsServiceImpl.java
+++ b/project-root/backend/src/main/java/com/readrecords/backend/service/RegisterBookRecordsServiceImpl.java
@@ -50,7 +50,7 @@ public class RegisterBookRecordsServiceImpl
       message = REGISTER_SUCCESS_MESSAGE;
     } else {
       // 既に登録済みであることを通知
-      message = REGISTER_SUCCESS_MESSAGE;
+      message = DUPLICATE_RECORD_MESSAGE;
     }
     return message;
   }


### PR DESCRIPTION
## Summary
- fix incorrect status returned when duplicate records are registered

## Testing
- `./mvnw test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68404cd8fac48332980e3c548de7132b