### PR TITLE
Rename convertPublicetionYear method

### DIFF
--- a/project-root/backend/src/main/java/com/readrecords/backend/controller/BookSearchApiController.java
+++ b/project-root/backend/src/main/java/com/readrecords/backend/controller/BookSearchApiController.java
@@ -71,7 +71,7 @@ public class BookSearchApiController {
     // 現在日付の取得(レコード登録用)
     Date date = new Date(Calendar.getInstance().getTimeInMillis());
     // 出版年のフォーマット変換
-    String convertPublicationYear = convertPublicetionYear(publicationYear);
+    String convertPublicationYear = convertPublicationYear(publicationYear);
     // 登録情報一覧
     logger.info(
         "ISBN: {}, bookName: {}, author: {}, genre: {}, publicationYear: {}, publisher: {}",
@@ -149,7 +149,7 @@ public class BookSearchApiController {
     return message;
   }
 
-  private String convertPublicetionYear(String publicationYear) {
+  private String convertPublicationYear(String publicationYear) {
     publicationYear = publicationYear.replace("年", "-");
     publicationYear = publicationYear.replace("月", "-");
     if (publicationYear.contains("日頃")) {


### PR DESCRIPTION
## Summary
- rename `convertPublicetionYear` to `convertPublicationYear`
- adjust call site for the renamed method

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c523dd32c8332a8fba0cb1c8eaff2